### PR TITLE
dump captions individually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 data
+
+# virtual env
+venv
+.venv

--- a/src/crawl.py
+++ b/src/crawl.py
@@ -84,7 +84,7 @@ def crawl_bokete():
                 captions.append(out)
         sleep(1)
     print("done")
-    with open("../data/cations/crawled_captions.pkl", "wb") as f:
+    with open("../data/captions/crawled_captions.pkl", "wb") as f:
         pickle.dump(captions, f)
 
 if __name__ == "__main__":

--- a/src/crawl.py
+++ b/src/crawl.py
@@ -38,8 +38,12 @@ def save_image(soup):
 
 def is_star_over_100(soup):
     # 評価順に元からsortされているので, 一番最初のbokeのみと比較するだけで良い
-    star_num = int(soup.find_all("div", attrs={"class": "boke"})[1]
-                   .find_all("div", attrs={"class" : "boke-stars"})[0].text.strip())
+    try:
+        top_boke = soup.find_all("div", attrs={"class": "boke"})[1]
+    except IndexError:
+        return False    # 1つもボケのないお題
+    star_num = int(top_boke.find_all("div", attrs={"class": "boke-stars"})[0]
+                   .text.strip())
     if star_num >= 100:
         return True
     else:

--- a/src/crawl.py
+++ b/src/crawl.py
@@ -84,7 +84,6 @@ def crawl_one_boke(soup):
 
 
 def crawl_bokete():
-    captions = []
     for odai_num in tqdm(range(1, ODAI_NUM + 1)):
         odai_dump_path = DATA_DIR / f'captions/{odai_num}.pkl'
         if odai_dump_path.exists():
@@ -96,7 +95,6 @@ def crawl_bokete():
             out = crawl_one_boke(soup)
             if out is not None:
                 out["odai_num"] = odai_num
-                captions.append(out)
                 with open(odai_dump_path, "wb") as f:
                     pickle.dump(out, f)
         sleep(1)


### PR DESCRIPTION
## お題毎のピックル化

captionをお題毎に`{odai_num}.pkl`として保存

## ボケがないページでIndexErrorが起きていた問題の修正

[ボケがないページ](https://bokete.jp/odai/145)

```
Traceback (most recent call last):
  File "crawl.py", line 99, in <module>
    crawl_bokete()
  File "crawl.py", line 89, in crawl_bokete
    out = crawl_one_boke(soup)
  File "crawl.py", line 49, in crawl_one_boke
    if is_star_over_100(soup):
  File "crawl.py", line 39, in is_star_over_100
    star_num = int(soup.find_all("div", attrs={"class": "boke"})[1]
IndexError: list index out of range
```

## ページの番号とpickleの`odai_num`を統一

pickleには-1された数値が格納されていたので統一